### PR TITLE
Little optimization for C

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -56,22 +56,20 @@ int func%d(char **error) {
     struct Dummy *d = dummy_new();
 
     a = func%d(error);
-    if(*error) {
-        dummy_delete(d);
-        return -1;
-    }
+    if(*error)
+        goto fail;
     b = func%d(error);
-    if(*error) {
-        dummy_delete(d);
-        return -1;
-    }
+    if(*error)
+        goto fail;
     c = func%d(error);
-    if(*error) {
-        dummy_delete(d);
-        return -1;
-    }
+    if(*error)
+        goto fail;
     dummy_delete(d);
     return a + b + c;
+
+fail:
+    dummy_delete(d);
+    return -1;
 }
 '''
 


### PR DESCRIPTION
This trick with `goto fail' is widely used with C. It changes size for C binary from 272416 to 223264 bytes (gcc 4.9.3). But in any case C++ code gives smaller binary (190584 bytes).